### PR TITLE
CI: docs: Pass the GitHub token as an input

### DIFF
--- a/.github/actions/docs/deploy/action.yml
+++ b/.github/actions/docs/deploy/action.yml
@@ -1,7 +1,12 @@
 name: 'Deploy to GitHub Pages'
+description: ''
 inputs:
   destination_dir:
     description: 'The directory where the site will be put on the publishing side.'
+    required: true
+
+  github_token:
+    description: 'The GitHub token to use for pushing the GitHub pages.'
     required: true
 
 
@@ -11,7 +16,7 @@ runs:
     - name: 'Deploy'
       uses: 'peaceiris/actions-gh-pages@v3'
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: '${{ inputs.github_token }}'
         publish_dir: './nimble-build/docs'
         destination_dir: '${{ inputs.destination_dir }}'
         user_name: 'github-actions[bot]'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,3 +41,4 @@ jobs:
         uses: './.github/actions/docs/deploy'
         with:
           destination_dir: '${{ inputs.gh_pages_dest_dir }}'
+          github_token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Composite actions can not access the "secrets" context.